### PR TITLE
add basic support for a non supported language request exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ bt.translate('This hotel is located close to the centre of Paris.', 'en', 'ro', 
   console.log(err, res);
 });
 ```
+
+## Language List Reference
+
+Please refer to [this link](https://msdn.microsoft.com/en-us/library/hh456380.aspx) for the
+complete list of the languages supported by BING.

--- a/demo.js
+++ b/demo.js
@@ -6,3 +6,9 @@ var bt = require('./lib/bing-translate.js').init({
 bt.translate('This hotel is located close to the centre of Paris.', 'en', 'ro', function(err, res){
   console.log(err, res);
 });
+
+// this example will throw an exception error because "se" is not recognised
+// as language in bing
+bt.translate('ska', 'se', 'en', function(err, res){
+  console.log(err, res);
+});

--- a/lib/bing-translate.js
+++ b/lib/bing-translate.js
@@ -31,11 +31,18 @@ client.translate = function(text, from, to, callback){
         data += chunk;
       });
       response.on('end', function(){
-        callback(null, {
+        var error, translation;
+        try {
+          translation = regx.exec(data)[1];
+        } catch(e) {
+          error = 'parse-exception';
+        }
+        callback(error, {
           original_text: text,
-          translated_text: regx.exec(data)[1],
+          translated_text: translation,
           from_language: from,
-          to_language: to
+          to_language: to,
+          response: data
         });
       });
     });


### PR DESCRIPTION
When you request a translation from a non supported language the instruction `translation = regx.exec(data)[1];` will cause an unhandled exception.

I've just wrapped that into a try/catch block to handle this exception, it may be improved so to fetch the real exception from the server response.